### PR TITLE
Fix "usage" for "rank" attribute

### DIFF
--- a/lib/deps/attributs.js
+++ b/lib/deps/attributs.js
@@ -114,7 +114,7 @@ var attrs = {
   "pos" :                { "usage" : "EN",   "type" : "point" },
   "quadtree" :           { "usage" : "G",    "type" : "quadType" },
   "quantum" :            { "usage" : "G",    "type" : "double" },
-  "rank" :               { "usage" : "S",    "type" : "rankType" },
+  "rank" :               { "usage" : "C",    "type" : "rankType" },
   "rankdir" :            { "usage" : "G",    "type" : "rankdir" },
   "ranksep" :            { "usage" : "G",    "type" : "double" },
   "ratio" :              { "usage" : "G",    "type" : "string" },


### PR DESCRIPTION
Changed value of "usage" property from "S" to "C".

Fixes validation bug for cluster attributes, where system incorrectly rejects assertions of the "rank" attribute.